### PR TITLE
Experiment: Review Overview Zoom and Navigation

### DIFF
--- a/desktop/src/desktop_system.rs
+++ b/desktop/src/desktop_system.rs
@@ -347,7 +347,7 @@ impl DesktopSystem {
 
         // Update the hover target.
         {
-            // Use keyboard focus for the howver if we are not focusing the thing directly.
+            // Use keyboard focus for the hover if we are not focusing the thing directly.
             let hover_target = if self.user_state.focus_depth != FocusDepth::default() {
                 self.event_router.keyboard_focus()
             } else {

--- a/desktop/src/desktop_system.rs
+++ b/desktop/src/desktop_system.rs
@@ -99,22 +99,34 @@ pub type DesktopFocusPath = FocusPath<DesktopTarget>;
 pub type Commands = CollectingVec<DesktopCommand>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum UserState {
-    #[default]
-    Focused,
-    Overview(OverviewTarget),
+pub struct UserState {
+    focus_depth: FocusDepth,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum OverviewTarget {
-    Visor(LaunchProfileId),
-    MatrixRow(LaunchProfileId),
-    Project(ProjectId),
+/// What is the user currently focusing on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::EnumCount, strum::FromRepr)]
+#[repr(u8)]
+pub enum FocusDepth {
+    #[default]
+    Instance,
+    Launcher,
+    Row,
+    Project,
     Desktop,
 }
 
+impl FocusDepth {
+    pub fn zoom_in(self) -> Option<Self> {
+        Self::from_repr((self as u8).checked_sub(1)?)
+    }
+
+    pub fn zoom_out(self) -> Option<Self> {
+        Self::from_repr((self as u8).checked_add(1)?)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum FocusReason {
+pub(super) enum KeyboardFocusReason {
     InputTransition,
     StopInstanceReplacement,
     PresentInstance,
@@ -122,14 +134,14 @@ pub(super) enum FocusReason {
     PromotePrimaryView,
 }
 
-impl FocusReason {
+impl KeyboardFocusReason {
     pub fn resets_navigation_affinity(self) -> bool {
         match self {
-            FocusReason::Navigate => false,
-            FocusReason::InputTransition
-            | FocusReason::StopInstanceReplacement
-            | FocusReason::PresentInstance
-            | FocusReason::PromotePrimaryView => true,
+            KeyboardFocusReason::Navigate => false,
+            KeyboardFocusReason::InputTransition
+            | KeyboardFocusReason::StopInstanceReplacement
+            | KeyboardFocusReason::PresentInstance
+            | KeyboardFocusReason::PromotePrimaryView => true,
         }
     }
 }
@@ -244,7 +256,7 @@ impl DesktopSystem {
 
             event_router,
             camera: scene.animated(PixelCamera::default()),
-            user_state: UserState::Focused,
+            user_state: UserState::default(),
             navigation_control: NavigationControl::default(),
             deferred_focus_launcher_measures: Default::default(),
             deferred_camera_move: false,

--- a/desktop/src/desktop_system.rs
+++ b/desktop/src/desktop_system.rs
@@ -287,7 +287,7 @@ impl DesktopSystem {
 
         let mut measures = MeasureSet::Empty;
         let user_state_before = self.user_state.clone();
-        let focus_before = self.event_router.focused().cloned();
+        let focus_before = self.event_router.keyboard_focus().cloned();
 
         let mut changes: VecDeque<DesktopChange> = changes.into_iter().collect();
 
@@ -305,7 +305,7 @@ impl DesktopSystem {
 
         // The camera follows the focused target, so a focus change recomputes it even when the
         // change moved no layout (pure navigation between siblings, or focusing a launcher).
-        let mut update_camera = self.event_router.focused() != focus_before.as_ref();
+        let mut update_camera = self.event_router.keyboard_focus() != focus_before.as_ref();
         if self.user_state != user_state_before {
             update_camera = true;
         }
@@ -345,8 +345,18 @@ impl DesktopSystem {
         // no root measure is needed here.
         self.run_effects_to_completion(effects_mode, effects)?;
 
-        // Sync the hover rect.
-        self.sync_hover_with_target(self.event_router.pointer_focus().cloned().as_ref());
+        // Update the hover target.
+        {
+            // Use keyboard focus for the howver if we are not focusing the thing directly.
+            let hover_target = if self.user_state.focus_depth != FocusDepth::default() {
+                self.event_router.keyboard_focus()
+            } else {
+                self.event_router.pointer_focus()
+            };
+
+            // Sync the hover rect.
+            self.sync_hover_with_target(hover_target.cloned().as_ref());
+        }
 
         // Sync the window state (title, cursor) from the focused view after all effects settle.
         self.apply_focused_view_window_state()?;
@@ -434,7 +444,7 @@ impl DesktopSystem {
     }
 
     pub fn focused_view_window_state(&self) -> Result<Option<ViewWindowState>> {
-        let Some(focused) = self.event_router.focused() else {
+        let Some(focused) = self.event_router.keyboard_focus() else {
             return Ok(None);
         };
 
@@ -489,7 +499,7 @@ impl DesktopSystem {
     }
 
     pub(super) fn focused_path(&self) -> DesktopFocusPath {
-        self.path_of(self.event_router.focused())
+        self.path_of(self.event_router.keyboard_focus())
     }
 
     pub(super) fn path_of<'a>(

--- a/desktop/src/desktop_system/change.rs
+++ b/desktop/src/desktop_system/change.rs
@@ -4,7 +4,7 @@ use massive_util::CollectingVec;
 
 use crate::{
     DesktopTarget,
-    desktop_system::{FocusReason, ProjectCommand, UserState},
+    desktop_system::{KeyboardFocusReason, ProjectCommand, UserState},
     event_router::EventTransitions,
     instance_presenter::InstanceRoot,
     projects::LaunchProfileId,
@@ -35,7 +35,7 @@ pub enum DesktopChange {
     SetFocus {
         // None: Completely removes the focus from the application.
         target: Option<DesktopTarget>,
-        reason: FocusReason,
+        reason: KeyboardFocusReason,
     },
     /// Commits the navigation column affinity. `None` clears it (used by non-navigation focus
     /// changes via `set_focus_change`).
@@ -51,7 +51,7 @@ pub enum DesktopChange {
 /// Emits `SetFocus`, and — when the focus reason resets navigation affinity — a sibling
 /// `SetNavigationAffinity(None)` so the reset flows through change application rather than being
 /// applied inline in `focus()`.
-pub fn set_focus(target: Option<DesktopTarget>, reason: FocusReason) -> Changes {
+pub fn set_focus(target: Option<DesktopTarget>, reason: KeyboardFocusReason) -> Changes {
     let mut changes: Changes = DesktopChange::SetFocus { target, reason }.into();
     if reason.resets_navigation_affinity() {
         changes += DesktopChange::SetNavigationAffinity(None);

--- a/desktop/src/desktop_system/command_dispatch.rs
+++ b/desktop/src/desktop_system/command_dispatch.rs
@@ -11,7 +11,7 @@ use crate::desktop_system::change::{
     Changes, DesktopChange, ProjectChange, TopologyChange, set_focus,
 };
 use crate::desktop_system::effects::MeasureSet;
-use crate::desktop_system::zoom_navigation::{zoom_in, zoom_out};
+use crate::desktop_system::zoom_navigation::{focus_depth_from_target, zoom_in, zoom_out};
 use crate::desktop_system::{ProjectCommand, UserState};
 use crate::instance_manager::{InstanceManager, ViewPath};
 use crate::instance_presenter::InstanceRoot;
@@ -157,6 +157,19 @@ impl DesktopSystem {
                     })
                     .unwrap_or_else(|| self.user_state.clone());
                 Ok(DesktopChange::SetUserState(user_state).into())
+            }
+            DesktopCommand::ResetZoom => {
+                if let Some(keyboard_focus) = self.event_router.keyboard_focus() {
+                    let current_level = self.user_state.focus_depth;
+                    let keyboard_focus_level = focus_depth_from_target(keyboard_focus);
+
+                    if current_level != keyboard_focus_level {
+                        let mut new_user_state = self.user_state.clone();
+                        new_user_state.focus_depth = keyboard_focus_level;
+                        return Ok(DesktopChange::SetUserState(new_user_state).into());
+                    }
+                }
+                Ok([].into())
             }
             DesktopCommand::Navigate(direction) => self.plan_navigate(direction),
         }

--- a/desktop/src/desktop_system/command_dispatch.rs
+++ b/desktop/src/desktop_system/command_dispatch.rs
@@ -109,7 +109,7 @@ impl DesktopSystem {
                 //
                 // Detail: This causes an unfocus event sent to the instance's view which may
                 // unexpected while tear down.
-                let replacement_focus = self.event_router.focused().and_then(|focused| {
+                let replacement_focus = self.event_router.keyboard_focus().and_then(|focused| {
                     self.aggregates
                         .hierarchy
                         .resolve_replacement_focus_for_stopping_instance(focused, instance)
@@ -131,7 +131,7 @@ impl DesktopSystem {
             DesktopCommand::ZoomIn => {
                 let user_state = self
                     .event_router
-                    .focused()
+                    .keyboard_focus()
                     .and_then(|focused| {
                         zoom_in(
                             &self.aggregates.hierarchy,
@@ -146,7 +146,7 @@ impl DesktopSystem {
             DesktopCommand::ZoomOut => {
                 let user_state = self
                     .event_router
-                    .focused()
+                    .keyboard_focus()
                     .and_then(|focused| {
                         zoom_out(
                             &self.aggregates.hierarchy,
@@ -422,7 +422,7 @@ impl DesktopSystem {
                 // focus transition (and its navigation-affinity reset) flows through change
                 // application like every other focus change.
                 if let (Some(DesktopTarget::Instance(focused_instance)), ViewRole::Primary) =
-                    (self.event_router.focused(), &creation_info.role)
+                    (self.event_router.keyboard_focus(), &creation_info.role)
                     && *focused_instance == instance
                 {
                     output.changes += set_focus(

--- a/desktop/src/desktop_system/command_dispatch.rs
+++ b/desktop/src/desktop_system/command_dispatch.rs
@@ -139,7 +139,6 @@ impl DesktopSystem {
                             focused.clone(),
                             self.user_state.clone(),
                         )
-                        .into()
                     })
                     .unwrap_or_else(|| self.user_state.clone());
                 Ok(DesktopChange::SetUserState(user_state).into())
@@ -155,7 +154,6 @@ impl DesktopSystem {
                             focused.clone(),
                             self.user_state.clone(),
                         )
-                        .into()
                     })
                     .unwrap_or_else(|| self.user_state.clone());
                 Ok(DesktopChange::SetUserState(user_state).into())

--- a/desktop/src/desktop_system/command_dispatch.rs
+++ b/desktop/src/desktop_system/command_dispatch.rs
@@ -11,7 +11,7 @@ use crate::desktop_system::change::{
     Changes, DesktopChange, ProjectChange, TopologyChange, set_focus,
 };
 use crate::desktop_system::effects::MeasureSet;
-use crate::desktop_system::zoom_navigation::{focus_depth_from_target, zoom_in, zoom_out};
+use crate::desktop_system::zoom_navigation::focus_depth_from_target;
 use crate::desktop_system::{ProjectCommand, UserState};
 use crate::instance_manager::{InstanceManager, ViewPath};
 use crate::instance_presenter::InstanceRoot;
@@ -46,7 +46,7 @@ impl DesktopSystem {
     /// Plan the execution of a command.
     pub fn plan(&self, command: DesktopCommand, scene: &Scene) -> Result<Changes> {
         match command {
-            DesktopCommand::Project(project_command) => self.plan_project(project_command),
+            DesktopCommand::Project(project_command) => return self.plan_project(project_command),
             DesktopCommand::StartInstance {
                 launcher,
                 instance,
@@ -96,7 +96,7 @@ impl DesktopSystem {
                 );
                 changes += DesktopChange::SetUserState(UserState::default());
 
-                Ok(changes)
+                return Ok(changes);
             }
             DesktopCommand::StopInstance(instance) => {
                 let launcher = self
@@ -126,37 +126,19 @@ impl DesktopSystem {
                 ];
                 changes += DesktopChange::SetUserState(UserState::default());
 
-                Ok(changes)
+                return Ok(changes);
             }
             DesktopCommand::ZoomIn => {
-                let user_state = self
-                    .event_router
-                    .keyboard_focus()
-                    .and_then(|focused| {
-                        zoom_in(
-                            &self.aggregates.hierarchy,
-                            &self.aggregates.launchers,
-                            focused.clone(),
-                            self.user_state.clone(),
-                        )
-                    })
-                    .unwrap_or_else(|| self.user_state.clone());
-                Ok(DesktopChange::SetUserState(user_state).into())
+                if let Some(focus_depth) = self.user_state.focus_depth.zoom_in() {
+                    let user_state = UserState { focus_depth };
+                    return Ok(DesktopChange::SetUserState(user_state).into());
+                }
             }
             DesktopCommand::ZoomOut => {
-                let user_state = self
-                    .event_router
-                    .keyboard_focus()
-                    .and_then(|focused| {
-                        zoom_out(
-                            &self.aggregates.hierarchy,
-                            &self.aggregates.launchers,
-                            focused.clone(),
-                            self.user_state.clone(),
-                        )
-                    })
-                    .unwrap_or_else(|| self.user_state.clone());
-                Ok(DesktopChange::SetUserState(user_state).into())
+                if let Some(focus_depth) = self.user_state.focus_depth.zoom_out() {
+                    let user_state = UserState { focus_depth };
+                    return Ok(DesktopChange::SetUserState(user_state).into());
+                }
             }
             DesktopCommand::ResetZoom => {
                 if let Some(keyboard_focus) = self.event_router.keyboard_focus() {
@@ -169,10 +151,11 @@ impl DesktopSystem {
                         return Ok(DesktopChange::SetUserState(new_user_state).into());
                     }
                 }
-                Ok([].into())
             }
-            DesktopCommand::Navigate(direction) => self.plan_navigate(direction),
+            DesktopCommand::Navigate(direction) => return self.plan_navigate(direction),
         }
+
+        Ok([].into())
     }
 
     fn plan_project(&self, command: ProjectCommand) -> Result<Changes> {

--- a/desktop/src/desktop_system/command_dispatch.rs
+++ b/desktop/src/desktop_system/command_dispatch.rs
@@ -6,7 +6,7 @@ use massive_applications::{
 };
 use massive_shell::Scene;
 
-use super::{DesktopCommand, DesktopSystem, DesktopTarget, FocusReason};
+use super::{DesktopCommand, DesktopSystem, DesktopTarget, KeyboardFocusReason};
 use crate::desktop_system::change::{
     Changes, DesktopChange, ProjectChange, TopologyChange, set_focus,
 };
@@ -92,9 +92,9 @@ impl DesktopSystem {
                 ];
                 changes += set_focus(
                     Some(DesktopTarget::Instance(instance)),
-                    FocusReason::PresentInstance,
+                    KeyboardFocusReason::PresentInstance,
                 );
-                changes += DesktopChange::SetUserState(UserState::Focused);
+                changes += DesktopChange::SetUserState(UserState::default());
 
                 Ok(changes)
             }
@@ -117,14 +117,14 @@ impl DesktopSystem {
 
                 let mut changes = Changes::Empty;
                 if let Some(focus) = replacement_focus {
-                    changes += set_focus(Some(focus), FocusReason::StopInstanceReplacement);
+                    changes += set_focus(Some(focus), KeyboardFocusReason::StopInstanceReplacement);
                 }
                 changes += [
                     DesktopChange::Topology(TopologyChange::Remove(instance.into())),
                     DesktopChange::HideInstance { launcher, instance },
                     DesktopChange::ShutdownInstance(instance),
                 ];
-                changes += DesktopChange::SetUserState(UserState::Focused);
+                changes += DesktopChange::SetUserState(UserState::default());
 
                 Ok(changes)
             }
@@ -429,7 +429,7 @@ impl DesktopSystem {
                 {
                     output.changes += set_focus(
                         Some(DesktopTarget::View(creation_info.id)),
-                        FocusReason::PromotePrimaryView,
+                        KeyboardFocusReason::PromotePrimaryView,
                     );
                 }
                 Ok(output)

--- a/desktop/src/desktop_system/commands.rs
+++ b/desktop/src/desktop_system/commands.rs
@@ -26,6 +26,7 @@ pub enum DesktopCommand {
 
     ZoomIn,
     ZoomOut,
+    ResetZoom,
     Navigate(Direction),
 }
 

--- a/desktop/src/desktop_system/focus_input.rs
+++ b/desktop/src/desktop_system/focus_input.rs
@@ -167,7 +167,7 @@ impl DesktopSystem {
         if self
             .aggregates
             .hierarchy
-            .path_contains_target(self.event_router.focused(), target)
+            .path_contains_target(self.event_router.keyboard_focus(), target)
         {
             let parent = self.aggregates.hierarchy.parent(target).cloned();
             self.focus(

--- a/desktop/src/desktop_system/focus_input.rs
+++ b/desktop/src/desktop_system/focus_input.rs
@@ -10,7 +10,7 @@ use massive_input::Event;
 use massive_renderer::RenderGeometry;
 
 use super::navigation::Direction;
-use super::{DesktopCommand, DesktopSystem, DesktopTarget, FocusReason};
+use super::{DesktopCommand, DesktopSystem, DesktopTarget, KeyboardFocusReason};
 use crate::EventTransition;
 use crate::desktop_system::change::{Changes, DesktopChange, set_focus};
 use crate::event_router::{EventTransitions, ProcessOutcome};
@@ -42,7 +42,7 @@ impl DesktopSystem {
                 if let Some(target) = target {
                     let t = target.target;
                     let mut changes: Changes =
-                        set_focus(Some(t.clone()), FocusReason::InputTransition);
+                        set_focus(Some(t.clone()), KeyboardFocusReason::InputTransition);
 
                     if let Some(event) = target.event {
                         changes +=
@@ -50,7 +50,7 @@ impl DesktopSystem {
                     }
                     changes
                 } else {
-                    set_focus(None, FocusReason::InputTransition)
+                    set_focus(None, KeyboardFocusReason::InputTransition)
                 }
             }
         };
@@ -62,7 +62,7 @@ impl DesktopSystem {
         &mut self,
         target: impl Into<Option<&'a DesktopTarget>>,
         instance_manager: &InstanceManager,
-        _reason: FocusReason,
+        _reason: KeyboardFocusReason,
     ) -> Result<()> {
         let transitions = self.event_router.focus(target.into());
 
@@ -173,7 +173,7 @@ impl DesktopSystem {
             self.focus(
                 parent.as_ref(),
                 instance_manager,
-                FocusReason::InputTransition,
+                KeyboardFocusReason::InputTransition,
             )?;
         }
         Ok(())

--- a/desktop/src/desktop_system/focus_input.rs
+++ b/desktop/src/desktop_system/focus_input.rs
@@ -189,13 +189,13 @@ impl DesktopSystem {
             event: key_event, ..
         } = event.event()
             && key_event.state == ElementState::Pressed
-            && !key_event.repeat
             && event.device_states().is_command()
         {
             let focused_path = self.focused_path();
 
             // Simplify: Instance should probably return the launcher, too now.
-            if let Some(instance) = focused_path.instance()
+            if !key_event.repeat
+                && let Some(instance) = focused_path.instance()
                 && let Some(DesktopTarget::Launcher(launcher)) =
                     self.aggregates.hierarchy.parent(&instance.into())
             {

--- a/desktop/src/desktop_system/focus_input.rs
+++ b/desktop/src/desktop_system/focus_input.rs
@@ -13,6 +13,7 @@ use super::navigation::Direction;
 use super::{DesktopCommand, DesktopSystem, DesktopTarget, KeyboardFocusReason};
 use crate::EventTransition;
 use crate::desktop_system::change::{Changes, DesktopChange, set_focus};
+use crate::desktop_system::zoom_navigation::focus_depth_from_target;
 use crate::event_router::{EventTransitions, ProcessOutcome};
 use crate::hit_tester::AggregateHitTester;
 use crate::instance_manager::InstanceManager;
@@ -179,6 +180,10 @@ impl DesktopSystem {
         Ok(())
     }
 
+    /// Architecture: Somehow the desktop presenter should be handle these (we need some kind of
+    /// event delivery down / up?)
+    ///
+    /// Design: This function is mixing state checks with the key detection.
     pub fn match_desktop_keyboard_shortcut(
         &self,
         event: &Event<ViewEvent>,
@@ -210,6 +215,21 @@ impl DesktopSystem {
                         return Some(DesktopKeyboardShortcut::CloseInstance(instance));
                     }
                     _ => {}
+                }
+            }
+
+            if !key_event.repeat
+                && key_event.logical_key == Key::Named(NamedKey::Enter)
+                && let Some(keyboard_focus) = self.event_router.keyboard_focus()
+            {
+                // Architecture: When we issue ResetZoom redundantly, we could capture the
+                // `Cmd+Enter` in situations in which it needs to be delivered to the
+                // `LauncherPresenter`. Therefore, we test upfront if the ResetZoom is needed.
+                let current_level = self.user_state.focus_depth;
+                let keyboard_focus_level = focus_depth_from_target(keyboard_focus);
+
+                if current_level != keyboard_focus_level {
+                    return Some(DesktopKeyboardShortcut::ResetZoom);
                 }
             }
 
@@ -260,6 +280,7 @@ pub enum DesktopKeyboardShortcut {
     CloseInstance(InstanceId),
     ZoomOut,
     ZoomIn,
+    ResetZoom,
     Navigate(Direction),
 }
 
@@ -275,6 +296,7 @@ impl DesktopKeyboardShortcut {
             Self::CloseInstance(instance) => DesktopCommand::StopInstance(instance),
             Self::ZoomOut => DesktopCommand::ZoomOut,
             Self::ZoomIn => DesktopCommand::ZoomIn,
+            Self::ResetZoom => DesktopCommand::ResetZoom,
             Self::Navigate(direction) => DesktopCommand::Navigate(direction),
         }
     }

--- a/desktop/src/desktop_system/focus_input.rs
+++ b/desktop/src/desktop_system/focus_input.rs
@@ -180,7 +180,7 @@ impl DesktopSystem {
         Ok(())
     }
 
-    /// Architecture: Somehow the desktop presenter should be handle these (we need some kind of
+    /// Architecture: Somehow the desktop presenter should handle these (we need some kind of
     /// event delivery down / up?)
     ///
     /// Design: This function is mixing state checks with the key detection.

--- a/desktop/src/desktop_system/layout_effects.rs
+++ b/desktop/src/desktop_system/layout_effects.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 
 use log::error;
 use massive_animation::Interpolation;
-use massive_applications::InstanceId;
-use massive_geometry::{Point, SizePx, Transform};
-use massive_layout::{LayoutTopology, Placement, Size as LayoutSize};
+use massive_geometry::{SizePx, Transform};
+use massive_layout::LayoutTopology;
 
 use super::effects::{DesktopEffect, DesktopEffectScheduler, Effects};
 use super::layout_state::PlacementUpdate;
@@ -191,31 +190,6 @@ impl DesktopSystem {
         }
     }
 
-    pub(super) fn sync_hover_with_target(&mut self, target: Option<&DesktopTarget>) {
-        let hover_placement = match target {
-            Some(DesktopTarget::Instance(instance_id)) => {
-                Some(self.instance_hover_placement(*instance_id))
-            }
-            Some(DesktopTarget::View(view_id)) => match self
-                .aggregates
-                .hierarchy
-                .parent(&DesktopTarget::View(*view_id))
-            {
-                Some(DesktopTarget::Instance(instance_id)) => {
-                    Some(self.instance_hover_placement(*instance_id))
-                }
-                Some(_) => panic!("Internal error: View parent is not an instance"),
-                None => None,
-            },
-            Some(DesktopTarget::Launcher(launcher_id)) => {
-                Some(self.placement(&DesktopTarget::Launcher(*launcher_id)))
-            }
-            _ => None,
-        };
-
-        self.desktop_presenter.set_hover_placement(hover_placement);
-    }
-
     fn apply_layout(
         &mut self,
         target: DesktopTarget,
@@ -268,33 +242,4 @@ impl DesktopSystem {
             }
         }
     }
-
-    fn instance_hover_placement(&self, instance_id: InstanceId) -> Placement<Transform, 2> {
-        let mut placement = self.placement(&DesktopTarget::Instance(instance_id));
-
-        // Keep hover aligned with animated instance motion by composing the current instance-local
-        // animated transform with the launcher's world transform.
-        let Some(instance_presenter) = self.aggregates.instances.get(&instance_id) else {
-            return placement;
-        };
-        let Some(launcher_id) = self.aggregates.hierarchy.launcher_of_instance(instance_id) else {
-            return placement;
-        };
-        let launcher_placement = self.placement(&DesktopTarget::Launcher(launcher_id));
-
-        let launcher_anchor = layout_center(launcher_placement.rect.size);
-        let instance_anchor = layout_center(placement.rect.size);
-        placement.transform = Transform::compose_with_anchor(
-            launcher_placement.transform,
-            launcher_anchor,
-            *instance_presenter.layout_transform_animation.latest_value(),
-            instance_anchor,
-        );
-
-        placement
-    }
-}
-
-fn layout_center(size: LayoutSize<2>) -> Point {
-    Point::new(size[0] as f64 * 0.5, size[1] as f64 * 0.5)
 }

--- a/desktop/src/desktop_system/layout_effects.rs
+++ b/desktop/src/desktop_system/layout_effects.rs
@@ -173,7 +173,7 @@ impl DesktopSystem {
             return;
         };
 
-        // Hmm, I think there can't ba None case here.
+        // Hmm, I think there can't be a None case here.
         let camera_target =
             self.resolve_camera_for_target_and_or_ancestor_of(focused, self.user_state.focus_depth);
 

--- a/desktop/src/desktop_system/layout_effects.rs
+++ b/desktop/src/desktop_system/layout_effects.rs
@@ -175,7 +175,7 @@ impl DesktopSystem {
 
         // Hmm, I think there can't be a None case here.
         let camera_target =
-            self.resolve_camera_for_target_and_or_ancestor_of(focused, self.user_state.focus_depth);
+            self.resolve_camera_for_target_or_ancestor(focused, self.user_state.focus_depth);
 
         if let Some(camera) = camera_target {
             if effects_mode.animate() {

--- a/desktop/src/desktop_system/layout_effects.rs
+++ b/desktop/src/desktop_system/layout_effects.rs
@@ -174,8 +174,9 @@ impl DesktopSystem {
             return;
         };
 
+        // Hmm, I think there can't ba None case here.
         let camera_target =
-            self.resolve_camera_for_focus_and_or_ancestor_of(focused, self.user_state.focus_depth);
+            self.resolve_camera_for_target_and_or_ancestor_of(focused, self.user_state.focus_depth);
 
         if let Some(camera) = camera_target {
             if effects_mode.animate() {

--- a/desktop/src/desktop_system/layout_effects.rs
+++ b/desktop/src/desktop_system/layout_effects.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use log::error;
 use massive_animation::Interpolation;
 use massive_applications::InstanceId;
 use massive_geometry::{Point, SizePx, Transform};
@@ -7,9 +8,7 @@ use massive_layout::{LayoutTopology, Placement, Size as LayoutSize};
 
 use super::effects::{DesktopEffect, DesktopEffectScheduler, Effects};
 use super::layout_state::PlacementUpdate;
-use super::{
-    DesktopLayoutAlgorithm, DesktopSystem, DesktopTarget, TransactionEffectsMode, UserState,
-};
+use super::{DesktopLayoutAlgorithm, DesktopSystem, DesktopTarget, TransactionEffectsMode};
 use crate::instance_presenter::STRUCTURAL_ANIMATION_DURATION;
 
 impl DesktopSystem {
@@ -169,13 +168,14 @@ impl DesktopSystem {
             return;
         }
 
-        let camera_target = match &self.user_state {
-            UserState::Focused => self
-                .event_router
-                .focused()
-                .and_then(|target| self.camera_for_focus(target)),
-            UserState::Overview(target) => self.camera_for_overview_target(target),
+        let Some(focused) = self.event_router.focused() else {
+            // Not sure what we do if nothing is focused yet.
+            error!("Updating camera without something focused");
+            return;
         };
+
+        let camera_target =
+            self.resolve_camera_for_focus_and_or_ancestor_of(focused, self.user_state.focus_depth);
 
         if let Some(camera) = camera_target {
             if effects_mode.animate() {

--- a/desktop/src/desktop_system/layout_effects.rs
+++ b/desktop/src/desktop_system/layout_effects.rs
@@ -167,7 +167,7 @@ impl DesktopSystem {
             return;
         }
 
-        let Some(focused) = self.event_router.focused() else {
+        let Some(focused) = self.event_router.keyboard_focus() else {
             // Not sure what we do if nothing is focused yet.
             error!("Updating camera without something focused");
             return;

--- a/desktop/src/desktop_system/navigation.rs
+++ b/desktop/src/desktop_system/navigation.rs
@@ -116,46 +116,6 @@ impl DesktopSystem {
             return Ok(Changes::Empty);
         };
 
-        // match self.user_state.clone() {
-        //     UserState::Instance => {
-        //         if let Some(plan) = plan_navigation_candidate(
-        //             &self.aggregates.hierarchy,
-        //             &self.aggregates.launchers,
-        //             &self.navigation_control,
-        //             focused,
-        //             direction,
-        //         ) {
-        //             let mut changes =
-        //                 set_focus(Some(plan.candidate.clone()), FocusReason::Navigate);
-        //             changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
-        //             return Ok(changes);
-        //         }
-        //     }
-        //     UserState::Overview(target) => {
-        //         let Some(anchor) = overview_navigation_anchor(&target) else {
-        //             return Ok(Changes::Empty);
-        //         };
-
-        //         if let Some(plan) = plan_navigation_candidate_same_level(
-        //             &self.aggregates.hierarchy,
-        //             &self.aggregates.launchers,
-        //             &self.navigation_control,
-        //             &anchor,
-        //             direction,
-        //         ) && let Some(next_target) = overview_target_for_navigation_candidate(
-        //             &self.aggregates.hierarchy,
-        //             &target,
-        //             &plan.candidate,
-        //         ) {
-        //             let mut changes =
-        //                 set_focus(Some(plan.candidate.clone()), FocusReason::Navigate);
-        //             changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
-        //             changes += DesktopChange::SetUserState(UserState::Overview(next_target));
-        //             return Ok(changes);
-        //         }
-        //     }
-        // }
-
         if let Some(plan) = plan_navigation_candidate(
             &self.aggregates.hierarchy,
             &self.aggregates.launchers,
@@ -223,28 +183,6 @@ fn plan_navigation_candidate(
     let column_affinity = navigation_control.plan_column_affinity(direction, origin_placement);
     let target = navigate_from_origin(hierarchy, launchers, origin, direction, column_affinity)?;
     let candidate = normalize_navigation_target(hierarchy, launchers, target, direction);
-    Some(NavigationPlan {
-        candidate,
-        column_affinity,
-    })
-}
-
-/// Plans a same-level navigation step (used in overview) without mutating state.
-fn plan_navigation_candidate_same_level(
-    hierarchy: &DesktopTopology,
-    launchers: &LauncherMap,
-    navigation_control: &NavigationControl,
-    from: &DesktopTarget,
-    direction: Direction,
-) -> Option<NavigationPlan> {
-    if matches!(from, DesktopTarget::Instance(_)) && direction.vertical().is_some() {
-        return None;
-    }
-
-    let origin = resolve_navigation_origin(hierarchy, from)?;
-    let origin_placement = navigation_origin_placement(launchers, origin);
-    let column_affinity = navigation_control.plan_column_affinity(direction, origin_placement);
-    let candidate = navigate_from_origin(hierarchy, launchers, origin, direction, column_affinity)?;
     Some(NavigationPlan {
         candidate,
         column_affinity,
@@ -359,16 +297,6 @@ fn horizontal_child_neighbor(
         HorizontalDirection::Right => (index + 1 < instances.len()).then(|| instances[index + 1]),
     }
 }
-
-// pub fn overview_navigation_anchor(target: &OverviewTarget) -> Option<DesktopTarget> {
-//     match target {
-//         OverviewTarget::Visor(launcher_id) | OverviewTarget::MatrixRow(launcher_id) => {
-//             Some(DesktopTarget::Launcher(*launcher_id))
-//         }
-//         OverviewTarget::Project(project_id) => Some(DesktopTarget::Project(*project_id)),
-//         OverviewTarget::Desktop => Some(DesktopTarget::Desktop),
-//     }
-// }
 
 /// Normalizes a raw navigation result into a concrete, focusable target.
 ///

--- a/desktop/src/desktop_system/navigation.rs
+++ b/desktop/src/desktop_system/navigation.rs
@@ -4,11 +4,10 @@ use log::error;
 use massive_geometry::{PixelCamera, Rect, RectPx};
 use massive_scene::{ToCamera, Transform};
 
-use super::{DesktopSystem, DesktopTarget, FocusReason, UserState};
+use super::{DesktopSystem, DesktopTarget, KeyboardFocusReason};
+use crate::desktop_system::LauncherMap;
 use crate::desktop_system::change::{Changes, DesktopChange, set_focus};
 use crate::desktop_system::topology::DesktopTopology;
-use crate::desktop_system::zoom_navigation::overview_target_for_navigation_candidate;
-use crate::desktop_system::{LauncherMap, OverviewTarget};
 use crate::projects::{LaunchProfileId, LauncherMode, MatrixPlacement, ProjectId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,50 +116,63 @@ impl DesktopSystem {
             return Ok(Changes::Empty);
         };
 
-        match self.user_state.clone() {
-            UserState::Focused => {
-                if let Some(plan) = plan_navigation_candidate(
-                    &self.aggregates.hierarchy,
-                    &self.aggregates.launchers,
-                    &self.navigation_control,
-                    focused,
-                    direction,
-                ) {
-                    let mut changes =
-                        set_focus(Some(plan.candidate.clone()), FocusReason::Navigate);
-                    changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
-                    return Ok(changes);
-                }
-            }
-            UserState::Overview(target) => {
-                let Some(anchor) = overview_navigation_anchor(&target) else {
-                    return Ok(Changes::Empty);
-                };
+        // match self.user_state.clone() {
+        //     UserState::Instance => {
+        //         if let Some(plan) = plan_navigation_candidate(
+        //             &self.aggregates.hierarchy,
+        //             &self.aggregates.launchers,
+        //             &self.navigation_control,
+        //             focused,
+        //             direction,
+        //         ) {
+        //             let mut changes =
+        //                 set_focus(Some(plan.candidate.clone()), FocusReason::Navigate);
+        //             changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
+        //             return Ok(changes);
+        //         }
+        //     }
+        //     UserState::Overview(target) => {
+        //         let Some(anchor) = overview_navigation_anchor(&target) else {
+        //             return Ok(Changes::Empty);
+        //         };
 
-                if let Some(plan) = plan_navigation_candidate_same_level(
-                    &self.aggregates.hierarchy,
-                    &self.aggregates.launchers,
-                    &self.navigation_control,
-                    &anchor,
-                    direction,
-                ) && let Some(next_target) = overview_target_for_navigation_candidate(
-                    &self.aggregates.hierarchy,
-                    &target,
-                    &plan.candidate,
-                ) {
-                    let mut changes =
-                        set_focus(Some(plan.candidate.clone()), FocusReason::Navigate);
-                    changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
-                    changes += DesktopChange::SetUserState(UserState::Overview(next_target));
-                    return Ok(changes);
-                }
-            }
+        //         if let Some(plan) = plan_navigation_candidate_same_level(
+        //             &self.aggregates.hierarchy,
+        //             &self.aggregates.launchers,
+        //             &self.navigation_control,
+        //             &anchor,
+        //             direction,
+        //         ) && let Some(next_target) = overview_target_for_navigation_candidate(
+        //             &self.aggregates.hierarchy,
+        //             &target,
+        //             &plan.candidate,
+        //         ) {
+        //             let mut changes =
+        //                 set_focus(Some(plan.candidate.clone()), FocusReason::Navigate);
+        //             changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
+        //             changes += DesktopChange::SetUserState(UserState::Overview(next_target));
+        //             return Ok(changes);
+        //         }
+        //     }
+        // }
+
+        if let Some(plan) = plan_navigation_candidate(
+            &self.aggregates.hierarchy,
+            &self.aggregates.launchers,
+            &self.navigation_control,
+            focused,
+            direction,
+        ) {
+            let mut changes =
+                set_focus(Some(plan.candidate.clone()), KeyboardFocusReason::Navigate);
+            changes += DesktopChange::SetNavigationAffinity(plan.column_affinity);
+            return Ok(changes);
         }
 
         Ok(Changes::Empty)
     }
 
-    pub(super) fn camera_for_focus(&self, focus: &DesktopTarget) -> Option<PixelCamera> {
+    pub(super) fn camera_for_target(&self, focus: &DesktopTarget) -> Option<PixelCamera> {
         match focus {
             DesktopTarget::Desktop => {
                 let placement = self.placement(&DesktopTarget::Desktop);
@@ -189,7 +201,7 @@ impl DesktopSystem {
                 Some(transform.to_camera())
             }
             DesktopTarget::View(_) => {
-                self.camera_for_focus(self.aggregates.hierarchy.parent(focus)?)
+                self.camera_for_target(self.aggregates.hierarchy.parent(focus)?)
             }
         }
     }
@@ -348,15 +360,15 @@ fn horizontal_child_neighbor(
     }
 }
 
-pub fn overview_navigation_anchor(target: &OverviewTarget) -> Option<DesktopTarget> {
-    match target {
-        OverviewTarget::Visor(launcher_id) | OverviewTarget::MatrixRow(launcher_id) => {
-            Some(DesktopTarget::Launcher(*launcher_id))
-        }
-        OverviewTarget::Project(project_id) => Some(DesktopTarget::Project(*project_id)),
-        OverviewTarget::Desktop => Some(DesktopTarget::Desktop),
-    }
-}
+// pub fn overview_navigation_anchor(target: &OverviewTarget) -> Option<DesktopTarget> {
+//     match target {
+//         OverviewTarget::Visor(launcher_id) | OverviewTarget::MatrixRow(launcher_id) => {
+//             Some(DesktopTarget::Launcher(*launcher_id))
+//         }
+//         OverviewTarget::Project(project_id) => Some(DesktopTarget::Project(*project_id)),
+//         OverviewTarget::Desktop => Some(DesktopTarget::Desktop),
+//     }
+// }
 
 /// Normalizes a raw navigation result into a concrete, focusable target.
 ///

--- a/desktop/src/desktop_system/navigation.rs
+++ b/desktop/src/desktop_system/navigation.rs
@@ -111,7 +111,7 @@ impl DesktopSystem {
     pub(super) fn plan_navigate(&self, direction: Direction) -> Result<Changes> {
         // If nothing is focused (i.e. the whole window does not have the focused), we probably
         // don't want to do anything and this is perhaps even an error.
-        let Some(focused) = self.event_router.focused() else {
+        let Some(focused) = self.event_router.keyboard_focus() else {
             error!("Navigation request without active focus");
             return Ok(Changes::Empty);
         };

--- a/desktop/src/desktop_system/presentation.rs
+++ b/desktop/src/desktop_system/presentation.rs
@@ -2,7 +2,8 @@ use anyhow::{Result, bail};
 use log::warn;
 
 use massive_applications::{InstanceId, ViewCreationInfo};
-use massive_geometry::Vector3;
+use massive_geometry::{Point, Transform, Vector3};
+use massive_layout::{Placement, Size as LayoutSize};
 use massive_shell::Scene;
 
 use super::DesktopTarget;
@@ -143,4 +144,54 @@ impl DesktopSystem {
 
         Ok(ChangeOutput::changes(changes))
     }
+
+    pub(super) fn sync_hover_with_target(&mut self, target: Option<&DesktopTarget>) {
+        let Some(target) = target else {
+            self.desktop_presenter.set_hover_placement(None);
+            return;
+        };
+
+        let hover_placement = match target {
+            target @ (DesktopTarget::Instance(..) | DesktopTarget::View(..)) => self
+                .aggregates
+                .hierarchy
+                .instance_of_target(target)
+                .map(|instance_id| self.instance_hover_placement(instance_id)),
+            DesktopTarget::Launcher(launcher_id) => {
+                Some(self.placement(&DesktopTarget::Launcher(*launcher_id)))
+            }
+            _ => None,
+        };
+
+        self.desktop_presenter.set_hover_placement(hover_placement);
+    }
+
+    fn instance_hover_placement(&self, instance_id: InstanceId) -> Placement<Transform, 2> {
+        let mut placement = self.placement(&DesktopTarget::Instance(instance_id));
+
+        // Keep hover aligned with animated instance motion by composing the current instance-local
+        // animated transform with the launcher's world transform.
+        let Some(instance_presenter) = self.aggregates.instances.get(&instance_id) else {
+            return placement;
+        };
+        let Some(launcher_id) = self.aggregates.hierarchy.launcher_of_instance(instance_id) else {
+            return placement;
+        };
+        let launcher_placement = self.placement(&DesktopTarget::Launcher(launcher_id));
+
+        let launcher_anchor = layout_center(launcher_placement.rect.size);
+        let instance_anchor = layout_center(placement.rect.size);
+        placement.transform = Transform::compose_with_anchor(
+            launcher_placement.transform,
+            launcher_anchor,
+            *instance_presenter.layout_transform_animation.latest_value(),
+            instance_anchor,
+        );
+
+        placement
+    }
+}
+
+fn layout_center(size: LayoutSize<2>) -> Point {
+    Point::new(size[0] as f64 * 0.5, size[1] as f64 * 0.5)
 }

--- a/desktop/src/desktop_system/presentation.rs
+++ b/desktop/src/desktop_system/presentation.rs
@@ -169,23 +169,25 @@ impl DesktopSystem {
     fn instance_hover_placement(&self, instance_id: InstanceId) -> Placement<Transform, 2> {
         let mut placement = self.placement(&DesktopTarget::Instance(instance_id));
 
-        // Keep hover aligned with animated instance motion by composing the current instance-local
-        // animated transform with the launcher's world transform.
-        let Some(instance_presenter) = self.aggregates.instances.get(&instance_id) else {
-            return placement;
-        };
-        let Some(launcher_id) = self.aggregates.hierarchy.launcher_of_instance(instance_id) else {
-            return placement;
-        };
+        let instance_presenter = self
+            .aggregates
+            .instances
+            .get(&instance_id)
+            .expect("Instance not found");
+        let launcher_id = self
+            .aggregates
+            .hierarchy
+            .launcher_of_instance(instance_id)
+            .expect("Instance without launcher");
         let launcher_placement = self.placement(&DesktopTarget::Launcher(launcher_id));
 
-        let launcher_anchor = layout_center(launcher_placement.rect.size);
-        let instance_anchor = layout_center(placement.rect.size);
+        // Keep hover aligned with animated instance motion by composing the current instance-local
+        // animated transform with the launcher's world transform.
         placement.transform = Transform::compose_with_anchor(
             launcher_placement.transform,
-            launcher_anchor,
+            layout_center(launcher_placement.rect.size),
             *instance_presenter.layout_transform_animation.latest_value(),
-            instance_anchor,
+            layout_center(placement.rect.size),
         );
 
         placement

--- a/desktop/src/desktop_system/topology.rs
+++ b/desktop/src/desktop_system/topology.rs
@@ -13,6 +13,16 @@ impl OrderedHierarchy<DesktopTarget> {
             _ => None,
         }
     }
+
+    pub fn instance_of_target(&self, target: &DesktopTarget) -> Option<InstanceId> {
+        match target {
+            DesktopTarget::Instance(instance_id) => Some(*instance_id),
+            _ => self
+                .parent_of(target)
+                .and_then(|parent| self.instance_of_target(parent)),
+        }
+    }
+
     pub fn launcher_of_target(&self, target: &DesktopTarget) -> Option<LaunchProfileId> {
         match target {
             DesktopTarget::Launcher(launcher_id) => Some(*launcher_id),

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -32,7 +32,7 @@ pub(super) fn focus_depth_from_target(target: &DesktopTarget) -> FocusDepth {
 }
 
 impl DesktopSystem {
-    pub(super) fn resolve_camera_for_target_and_or_ancestor_of(
+    pub(super) fn resolve_camera_for_target_or_ancestor(
         &self,
         target: &DesktopTarget,
         mut depth: FocusDepth,

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -42,8 +42,7 @@ pub fn zoom_out(
     Some(user_state)
 }
 
-#[allow(dead_code)]
-fn focus_depth_from_target(target: DesktopTarget) -> FocusDepth {
+pub(super) fn focus_depth_from_target(target: &DesktopTarget) -> FocusDepth {
     match target {
         DesktopTarget::View(_) => FocusDepth::Instance,
         DesktopTarget::Instance(_) => FocusDepth::Instance,

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -2,14 +2,13 @@ use massive_geometry::{PixelCamera, Rect, RectPx, Size, SizePx, Vector3};
 use massive_layout::LayoutTopology;
 use massive_scene::{ToCamera, Transform};
 
-use crate::desktop_system::LauncherMap;
+use super::{DesktopSystem, DesktopTarget, UserState};
 use crate::desktop_system::topology::DesktopTopology;
+use crate::desktop_system::{FocusDepth, LauncherMap};
 use crate::projects::{LaunchProfileId, ProjectId};
 
-use super::{DesktopSystem, DesktopTarget, OverviewTarget, UserState};
-
 #[derive(Debug, Clone)]
-struct OverviewBounds {
+pub(super) struct OverviewBounds {
     rect: Rect,
     points: Vec<Vector3>,
 }
@@ -24,202 +23,179 @@ impl OverviewBounds {
 
 #[must_use]
 pub fn zoom_in(
-    topo: &DesktopTopology,
-    launchers: &LauncherMap,
-    focused: DesktopTarget,
-    user_state: UserState,
-) -> UserState {
-    {
-        match &user_state {
-            UserState::Focused => None,
-            UserState::Overview(target) => {
-                Some(next_inward_user_state(topo, launchers, focused, target))
-            }
-        }
-    }
-    .unwrap_or(user_state)
+    _topo: &DesktopTopology,
+    _launchers: &LauncherMap,
+    _focused: DesktopTarget,
+    mut user_state: UserState,
+) -> Option<UserState> {
+    user_state.focus_depth = user_state.focus_depth.zoom_in()?;
+    Some(user_state)
 }
 
 #[must_use]
 pub fn zoom_out(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    focused: DesktopTarget,
-    user_state: UserState,
-) -> UserState {
-    {
-        match &user_state {
-            UserState::Focused => first_overview_target_from_focus(topology, launchers, focused),
-            UserState::Overview(target) => Some(next_outward_overview_target(
-                topology, launchers, focused, target,
-            )),
-        }
-    }
-    .map(UserState::Overview)
-    .unwrap_or(user_state)
+    _topology: &DesktopTopology,
+    _launchers: &LauncherMap,
+    _focused: DesktopTarget,
+    mut user_state: UserState,
+) -> Option<UserState> {
+    user_state.focus_depth = user_state.focus_depth.zoom_out()?;
+    Some(user_state)
 }
 
-pub fn overview_target_for_navigation_candidate(
-    topology: &DesktopTopology,
-    current: &OverviewTarget,
-    candidate: &DesktopTarget,
-) -> Option<OverviewTarget> {
-    match current {
-        OverviewTarget::Visor(current_launcher) => {
-            let candidate_launcher = topology.launcher_of_target(candidate)?;
-            (candidate_launcher == *current_launcher)
-                .then_some(OverviewTarget::Visor(*current_launcher))
-        }
-        OverviewTarget::MatrixRow(current_launcher) => {
-            let current_project = topology.project_of_launcher(*current_launcher)?;
-            let candidate_launcher = topology.launcher_of_target(candidate)?;
-            let candidate_project = topology.project_of_launcher(candidate_launcher)?;
+// pub fn overview_target_for_navigation_candidate(
+//     topology: &DesktopTopology,
+//     current: &OverviewTarget,
+//     candidate: &DesktopTarget,
+// ) -> Option<OverviewTarget> {
+//     match current {
+//         OverviewTarget::Visor(current_launcher) => {
+//             let candidate_launcher = topology.launcher_of_target(candidate)?;
+//             (candidate_launcher == *current_launcher)
+//                 .then_some(OverviewTarget::Visor(*current_launcher))
+//         }
+//         OverviewTarget::MatrixRow(current_launcher) => {
+//             let current_project = topology.project_of_launcher(*current_launcher)?;
+//             let candidate_launcher = topology.launcher_of_target(candidate)?;
+//             let candidate_project = topology.project_of_launcher(candidate_launcher)?;
 
-            (candidate_project == current_project)
-                .then_some(OverviewTarget::MatrixRow(candidate_launcher))
-        }
-        OverviewTarget::Project(current_project) => {
-            let candidate_project = topology.project_of_target(candidate)?;
-            (candidate_project == *current_project)
-                .then_some(OverviewTarget::Project(*current_project))
-        }
-        OverviewTarget::Desktop => Some(OverviewTarget::Desktop),
-    }
-}
+//             (candidate_project == current_project)
+//                 .then_some(OverviewTarget::MatrixRow(candidate_launcher))
+//         }
+//         OverviewTarget::Project(current_project) => {
+//             let candidate_project = topology.project_of_target(candidate)?;
+//             (candidate_project == *current_project)
+//                 .then_some(OverviewTarget::Project(*current_project))
+//         }
+//         OverviewTarget::Desktop => Some(OverviewTarget::Desktop),
+//     }
+// }
 
-impl DesktopSystem {
-    pub(super) fn camera_for_overview_target(
-        &self,
-        target: &OverviewTarget,
-    ) -> Option<PixelCamera> {
-        match target {
-            OverviewTarget::Visor(launcher_id) => {
-                self.camera_for_bounds(self.visor_bounds(*launcher_id))
-            }
-            OverviewTarget::MatrixRow(launcher_id) => {
-                self.camera_for_rect(self.matrix_row_rect(*launcher_id)?)
-            }
-            OverviewTarget::Project(project_id) => {
-                self.camera_for_rect(self.project_rect(*project_id))
-            }
-            OverviewTarget::Desktop => self.camera_for_focus(&DesktopTarget::Desktop),
-        }
-    }
-}
+// impl DesktopSystem {
+//     pub(super) fn camera_for_overview_target(
+//         &self,
+//         target: &OverviewTarget,
+//     ) -> Option<PixelCamera> {
+//         match target {
+//             OverviewTarget::Visor(launcher_id) => {
+//                 self.camera_for_bounds(self.launcher_bounds(*launcher_id))
+//             }
+//             OverviewTarget::MatrixRow(launcher_id) => {
+//                 self.camera_for_rect(self.matrix_row_rect(*launcher_id)?)
+//             }
+//             OverviewTarget::Project(project_id) => {
+//                 self.camera_for_rect(self.project_rect(*project_id))
+//             }
+//             OverviewTarget::Desktop => self.camera_for_target(&DesktopTarget::Desktop),
+//         }
+//     }
+// }
 
-fn first_overview_target_from_focus(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    focused: DesktopTarget,
-) -> Option<OverviewTarget> {
-    if let Some(launcher_id) = topology.launcher_of_target(&focused) {
-        return Some(first_overview_target_for_launcher(
-            topology,
-            launchers,
-            launcher_id,
-        ));
-    }
-
-    if let Some(project_id) = topology.project_of_target(&focused) {
-        return Some(OverviewTarget::Project(project_id));
-    }
-
-    Some(OverviewTarget::Desktop)
-}
-
-fn first_overview_target_for_launcher(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    launcher_id: LaunchProfileId,
-) -> OverviewTarget {
-    if should_include_visor_level(topology, launcher_id) {
-        return OverviewTarget::Visor(launcher_id);
-    }
-
-    if should_include_matrix_row_level(topology, launchers, launcher_id) {
-        return OverviewTarget::MatrixRow(launcher_id);
-    }
-
-    topology
-        .project_of_launcher(launcher_id)
-        .map(OverviewTarget::Project)
-        .unwrap_or(OverviewTarget::Desktop)
-}
-
-fn next_inward_user_state(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    focused: DesktopTarget,
-    current: &OverviewTarget,
-) -> UserState {
-    match current {
-        OverviewTarget::Desktop => topology
-            .project_of_target(&focused)
-            .map(OverviewTarget::Project)
-            .map(UserState::Overview)
-            .unwrap_or(UserState::Focused),
-        OverviewTarget::Project(project_id) => {
-            let Some(launcher_id) =
-                zoom_context_launcher_for_project(topology, focused, *project_id)
-            else {
-                return UserState::Focused;
-            };
-
-            deepest_overview_target_for_launcher(topology, launchers, launcher_id)
-                .map(UserState::Overview)
-                .unwrap_or(UserState::Focused)
-        }
-        OverviewTarget::MatrixRow(launcher_id) => {
-            if should_include_visor_level(topology, *launcher_id) {
-                UserState::Overview(OverviewTarget::Visor(*launcher_id))
-            } else {
-                UserState::Focused
-            }
-        }
-        OverviewTarget::Visor(_) => UserState::Focused,
+fn focus_depth_from_target(target: DesktopTarget) -> FocusDepth {
+    match target {
+        DesktopTarget::View(_) => FocusDepth::Instance,
+        DesktopTarget::Instance(_) => FocusDepth::Instance,
+        DesktopTarget::Launcher(_) => FocusDepth::Launcher,
+        DesktopTarget::Project(_)
+        | DesktopTarget::ProjectHeader(_)
+        | DesktopTarget::ProjectMatrix(_) => FocusDepth::Project,
+        DesktopTarget::Desktop => FocusDepth::Desktop,
     }
 }
 
-fn deepest_overview_target_for_launcher(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    launcher_id: LaunchProfileId,
-) -> Option<OverviewTarget> {
-    if should_include_matrix_row_level(topology, launchers, launcher_id) {
-        return Some(OverviewTarget::MatrixRow(launcher_id));
-    }
+// fn first_overview_target_for_launcher(
+//     topology: &DesktopTopology,
+//     launchers: &LauncherMap,
+//     launcher_id: LaunchProfileId,
+// ) -> OverviewTarget {
+//     if should_include_visor_level(topology, launcher_id) {
+//         return OverviewTarget::Visor(launcher_id);
+//     }
 
-    if should_include_visor_level(topology, launcher_id) {
-        return Some(OverviewTarget::Visor(launcher_id));
-    }
+//     if should_include_matrix_row_level(topology, launchers, launcher_id) {
+//         return OverviewTarget::MatrixRow(launcher_id);
+//     }
 
-    None
-}
+//     topology
+//         .project_of_launcher(launcher_id)
+//         .map(OverviewTarget::Project)
+//         .unwrap_or(OverviewTarget::Desktop)
+// }
 
-fn next_outward_overview_target(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    focused: DesktopTarget,
-    current: &OverviewTarget,
-) -> OverviewTarget {
-    match current {
-        OverviewTarget::Visor(launcher_id) => {
-            if should_include_matrix_row_level(topology, launchers, *launcher_id) {
-                OverviewTarget::MatrixRow(*launcher_id)
-            } else {
-                zoom_transition_project(topology, focused, *launcher_id)
-                    .map(OverviewTarget::Project)
-                    .unwrap_or(OverviewTarget::Desktop)
-            }
-        }
-        OverviewTarget::MatrixRow(launcher_id) => {
-            zoom_transition_project(topology, focused, *launcher_id)
-                .map(OverviewTarget::Project)
-                .unwrap_or(OverviewTarget::Desktop)
-        }
-        OverviewTarget::Project(_) | OverviewTarget::Desktop => OverviewTarget::Desktop,
-    }
-}
+// fn next_inward_user_state(
+//     topology: &DesktopTopology,
+//     launchers: &LauncherMap,
+//     focused: DesktopTarget,
+//     current: &OverviewTarget,
+// ) -> UserState {
+//     match current {
+//         OverviewTarget::Desktop => topology
+//             .project_of_target(&focused)
+//             .map(OverviewTarget::Project)
+//             .map(UserState::Overview)
+//             .unwrap_or(UserState::Instance),
+//         OverviewTarget::Project(project_id) => {
+//             let Some(launcher_id) =
+//                 zoom_context_launcher_for_project(topology, focused, *project_id)
+//             else {
+//                 return UserState::Instance;
+//             };
+
+//             deepest_overview_target_for_launcher(topology, launchers, launcher_id)
+//                 .map(UserState::Overview)
+//                 .unwrap_or(UserState::Instance)
+//         }
+//         OverviewTarget::MatrixRow(launcher_id) => {
+//             if should_include_visor_level(topology, *launcher_id) {
+//                 UserState::Overview(OverviewTarget::Visor(*launcher_id))
+//             } else {
+//                 UserState::Instance
+//             }
+//         }
+//         OverviewTarget::Visor(_) => UserState::Instance,
+//     }
+// }
+
+// fn deepest_overview_target_for_launcher(
+//     topology: &DesktopTopology,
+//     launchers: &LauncherMap,
+//     launcher_id: LaunchProfileId,
+// ) -> Option<OverviewTarget> {
+//     if should_include_matrix_row_level(topology, launchers, launcher_id) {
+//         return Some(OverviewTarget::MatrixRow(launcher_id));
+//     }
+
+//     if should_include_visor_level(topology, launcher_id) {
+//         return Some(OverviewTarget::Visor(launcher_id));
+//     }
+
+//     None
+// }
+
+// fn next_outward_overview_target(
+//     topology: &DesktopTopology,
+//     launchers: &LauncherMap,
+//     focused: DesktopTarget,
+//     current: &OverviewTarget,
+// ) -> OverviewTarget {
+//     match current {
+//         OverviewTarget::Visor(launcher_id) => {
+//             if should_include_matrix_row_level(topology, launchers, *launcher_id) {
+//                 OverviewTarget::MatrixRow(*launcher_id)
+//             } else {
+//                 zoom_transition_project(topology, focused, *launcher_id)
+//                     .map(OverviewTarget::Project)
+//                     .unwrap_or(OverviewTarget::Desktop)
+//             }
+//         }
+//         OverviewTarget::MatrixRow(launcher_id) => {
+//             zoom_transition_project(topology, focused, *launcher_id)
+//                 .map(OverviewTarget::Project)
+//                 .unwrap_or(OverviewTarget::Desktop)
+//         }
+//         OverviewTarget::Project(_) | OverviewTarget::Desktop => OverviewTarget::Desktop,
+//     }
+// }
 
 fn zoom_transition_project(
     topology: &DesktopTopology,
@@ -282,14 +258,20 @@ fn zoom_context_launcher_for_project(
 }
 
 impl DesktopSystem {
-    fn visor_bounds(&self, launcher_id: crate::projects::LaunchProfileId) -> OverviewBounds {
+    pub(super) fn launcher_bounds(
+        &self,
+        launcher_id: crate::projects::LaunchProfileId,
+    ) -> OverviewBounds {
         let root = DesktopTarget::Launcher(launcher_id);
         let mut bounds = Some(self.target_bounds(&root));
         self.extend_bounds_with_subtree(&root, &mut bounds);
         bounds.expect("Internal error: launcher bounds should always exist")
     }
 
-    fn matrix_row_rect(&self, launcher_id: crate::projects::LaunchProfileId) -> Option<Rect> {
+    pub(super) fn matrix_row_rect(
+        &self,
+        launcher_id: crate::projects::LaunchProfileId,
+    ) -> Option<Rect> {
         let project_id = self.aggregates.hierarchy.project_of_launcher(launcher_id)?;
         let row = self.aggregates.launchers.get(&launcher_id)?.placement.row;
         let mut rect: Option<Rect> = None;
@@ -336,7 +318,7 @@ impl DesktopSystem {
         self.target_rect(&DesktopTarget::ProjectMatrix(project_id))
     }
 
-    fn project_rect(&self, project_id: crate::projects::ProjectId) -> Rect {
+    pub(super) fn project_rect(&self, project_id: crate::projects::ProjectId) -> Rect {
         let root = DesktopTarget::Project(project_id);
         let mut rect = Some(self.target_rect(&root));
         self.extend_rect_with_subtree(&root, &mut rect);
@@ -394,7 +376,51 @@ impl DesktopSystem {
         bounds.rect
     }
 
-    fn camera_for_bounds(&self, bounds: OverviewBounds) -> Option<PixelCamera> {
+    pub(super) fn resolve_camera_for_focus_and_or_ancestor_of(
+        &self,
+        focused: &DesktopTarget,
+        mut depth: FocusDepth,
+    ) -> Option<PixelCamera> {
+        loop {
+            if let Some(camera) = self.resolve_camera_focus_and_depth(focused, depth) {
+                return Some(camera);
+            }
+
+            depth = depth.zoom_out()?;
+        }
+    }
+
+    pub(super) fn resolve_camera_focus_and_depth(
+        &self,
+        focused: &DesktopTarget,
+        depth: FocusDepth,
+    ) -> Option<PixelCamera> {
+        match depth {
+            FocusDepth::Instance => self
+                .aggregates
+                .hierarchy
+                .instance_of_target(focused)
+                .and_then(|_| self.camera_for_target(focused)),
+            FocusDepth::Launcher => self
+                .aggregates
+                .hierarchy
+                .launcher_of_target(focused)
+                .and_then(|launcher| self.camera_for_bounds(self.launcher_bounds(launcher))),
+            FocusDepth::Row => self
+                .aggregates
+                .hierarchy
+                .launcher_of_target(focused)
+                .and_then(|launcher| self.camera_for_rect(self.matrix_row_rect(launcher)?)),
+            FocusDepth::Project => self
+                .aggregates
+                .hierarchy
+                .project_of_target(focused)
+                .and_then(|project| self.camera_for_rect(self.project_rect(project))),
+            FocusDepth::Desktop => self.camera_for_target(&DesktopTarget::Desktop),
+        }
+    }
+
+    pub(super) fn camera_for_bounds(&self, bounds: OverviewBounds) -> Option<PixelCamera> {
         if bounds.rect.is_empty() {
             return None;
         }
@@ -413,7 +439,7 @@ impl DesktopSystem {
         Some(camera.with_size(target_size))
     }
 
-    fn camera_for_rect(&self, rect: Rect) -> Option<PixelCamera> {
+    pub(super) fn camera_for_rect(&self, rect: Rect) -> Option<PixelCamera> {
         if rect.is_empty() {
             return None;
         }

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -1,9 +1,8 @@
 use massive_geometry::{PixelCamera, Rect, RectPx, Size, SizePx, Vector3};
 use massive_scene::{ToCamera, Transform};
 
-use super::{DesktopSystem, DesktopTarget, UserState};
-use crate::desktop_system::topology::DesktopTopology;
-use crate::desktop_system::{FocusDepth, LauncherMap};
+use super::{DesktopSystem, DesktopTarget};
+use crate::desktop_system::FocusDepth;
 use crate::projects::LaunchProfileId;
 
 #[derive(Debug, Clone)]
@@ -18,28 +17,6 @@ impl OverviewBounds {
         self.points.append(&mut other.points);
         self
     }
-}
-
-#[must_use]
-pub fn zoom_in(
-    _topo: &DesktopTopology,
-    _launchers: &LauncherMap,
-    _focused: DesktopTarget,
-    mut user_state: UserState,
-) -> Option<UserState> {
-    user_state.focus_depth = user_state.focus_depth.zoom_in()?;
-    Some(user_state)
-}
-
-#[must_use]
-pub fn zoom_out(
-    _topology: &DesktopTopology,
-    _launchers: &LauncherMap,
-    _focused: DesktopTarget,
-    mut user_state: UserState,
-) -> Option<UserState> {
-    user_state.focus_depth = user_state.focus_depth.zoom_out()?;
-    Some(user_state)
 }
 
 pub(super) fn focus_depth_from_target(target: &DesktopTarget) -> FocusDepth {

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -258,20 +258,14 @@ fn zoom_context_launcher_for_project(
 }
 
 impl DesktopSystem {
-    pub(super) fn launcher_bounds(
-        &self,
-        launcher_id: crate::projects::LaunchProfileId,
-    ) -> OverviewBounds {
+    pub(super) fn launcher_bounds(&self, launcher_id: LaunchProfileId) -> OverviewBounds {
         let root = DesktopTarget::Launcher(launcher_id);
         let mut bounds = Some(self.target_bounds(&root));
         self.extend_bounds_with_subtree(&root, &mut bounds);
         bounds.expect("Internal error: launcher bounds should always exist")
     }
 
-    pub(super) fn matrix_row_rect(
-        &self,
-        launcher_id: crate::projects::LaunchProfileId,
-    ) -> Option<Rect> {
+    pub(super) fn matrix_row_rect(&self, launcher_id: LaunchProfileId) -> Option<Rect> {
         let project_id = self.aggregates.hierarchy.project_of_launcher(launcher_id)?;
         let row = self.aggregates.launchers.get(&launcher_id)?.placement.row;
         let mut rect: Option<Rect> = None;
@@ -376,13 +370,13 @@ impl DesktopSystem {
         bounds.rect
     }
 
-    pub(super) fn resolve_camera_for_focus_and_or_ancestor_of(
+    pub(super) fn resolve_camera_for_target_and_or_ancestor_of(
         &self,
-        focused: &DesktopTarget,
+        target: &DesktopTarget,
         mut depth: FocusDepth,
     ) -> Option<PixelCamera> {
         loop {
-            if let Some(camera) = self.resolve_camera_focus_and_depth(focused, depth) {
+            if let Some(camera) = self.resolve_camera_focus_and_depth(target, depth) {
                 return Some(camera);
             }
 
@@ -392,31 +386,44 @@ impl DesktopSystem {
 
     pub(super) fn resolve_camera_focus_and_depth(
         &self,
-        focused: &DesktopTarget,
+        target: &DesktopTarget,
         depth: FocusDepth,
     ) -> Option<PixelCamera> {
         match depth {
             FocusDepth::Instance => self
                 .aggregates
                 .hierarchy
-                .instance_of_target(focused)
-                .and_then(|_| self.camera_for_target(focused)),
-            FocusDepth::Launcher => self
-                .aggregates
-                .hierarchy
-                .launcher_of_target(focused)
-                .and_then(|launcher| self.camera_for_bounds(self.launcher_bounds(launcher))),
+                .instance_of_target(target)
+                .and_then(|_| self.camera_for_target(target)),
+            FocusDepth::Launcher => self.camera_for_launcher_focus(target),
             FocusDepth::Row => self
                 .aggregates
                 .hierarchy
-                .launcher_of_target(focused)
+                .launcher_of_target(target)
                 .and_then(|launcher| self.camera_for_rect(self.matrix_row_rect(launcher)?)),
             FocusDepth::Project => self
                 .aggregates
                 .hierarchy
-                .project_of_target(focused)
+                .project_of_target(target)
                 .and_then(|project| self.camera_for_rect(self.project_rect(project))),
             FocusDepth::Desktop => self.camera_for_target(&DesktopTarget::Desktop),
+        }
+    }
+
+    fn camera_for_launcher_focus(&self, target: &DesktopTarget) -> Option<PixelCamera> {
+        let launcher_id = self.aggregates.hierarchy.launcher_of_target(target)?;
+        let launcher = DesktopTarget::Launcher(launcher_id);
+
+        if self
+            .aggregates
+            .hierarchy
+            .launcher_instances(launcher_id)
+            .len()
+            > 1
+        {
+            self.camera_for_bounds(self.launcher_bounds(launcher_id))
+        } else {
+            self.camera_for_target(&launcher)
         }
     }
 

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -56,118 +56,6 @@ fn focus_depth_from_target(target: DesktopTarget) -> FocusDepth {
 }
 
 impl DesktopSystem {
-    pub(super) fn launcher_bounds(&self, launcher_id: LaunchProfileId) -> OverviewBounds {
-        let root = DesktopTarget::Launcher(launcher_id);
-        let mut bounds = Some(self.target_bounds(&root));
-        self.extend_bounds_with_subtree(&root, &mut bounds);
-        bounds.expect("Internal error: launcher bounds should always exist")
-    }
-
-    pub(super) fn matrix_row_rect(&self, launcher_id: LaunchProfileId) -> Option<Rect> {
-        let project_id = self.aggregates.hierarchy.project_of_launcher(launcher_id)?;
-        let row = self.aggregates.launchers.get(&launcher_id)?.placement.row;
-        let mut rect: Option<Rect> = None;
-
-        for target in self
-            .aggregates
-            .hierarchy
-            .get_nested(&DesktopTarget::ProjectMatrix(project_id))
-        {
-            let DesktopTarget::Launcher(candidate_launcher) = target else {
-                continue;
-            };
-
-            let Some(candidate) = self.aggregates.launchers.get(candidate_launcher) else {
-                continue;
-            };
-
-            if candidate.placement.row != row {
-                continue;
-            }
-
-            let launcher_rect = self.target_rect(&DesktopTarget::Launcher(*candidate_launcher));
-
-            rect = Some(match rect {
-                Some(existing) => existing.joined(launcher_rect),
-                None => launcher_rect,
-            });
-        }
-
-        // Be sure the full width of the project is covered.
-        rect.map(|matrix_row_rect| {
-            let project_matrix_rect = self.project_matrix_rect(project_id);
-            (
-                project_matrix_rect.left,
-                matrix_row_rect.top,
-                project_matrix_rect.right,
-                matrix_row_rect.bottom,
-            )
-                .into()
-        })
-    }
-
-    fn project_matrix_rect(&self, project_id: crate::projects::ProjectId) -> Rect {
-        self.target_rect(&DesktopTarget::ProjectMatrix(project_id))
-    }
-
-    pub(super) fn project_rect(&self, project_id: crate::projects::ProjectId) -> Rect {
-        let root = DesktopTarget::Project(project_id);
-        let mut rect = Some(self.target_rect(&root));
-        self.extend_rect_with_subtree(&root, &mut rect);
-        rect.expect("Internal error: project bounds should always exist")
-    }
-
-    fn extend_rect_with_subtree(&self, root: &DesktopTarget, rect: &mut Option<Rect>) {
-        for child in self.aggregates.hierarchy.get_nested(root) {
-            let child_rect = self.target_rect(child);
-            *rect = Some(match *rect {
-                Some(existing) => existing.joined(child_rect),
-                None => child_rect,
-            });
-
-            self.extend_rect_with_subtree(child, rect);
-        }
-    }
-
-    fn extend_bounds_with_subtree(
-        &self,
-        root: &DesktopTarget,
-        bounds: &mut Option<OverviewBounds>,
-    ) {
-        for child in self.aggregates.hierarchy.get_nested(root) {
-            let child_bounds = self.target_bounds(child);
-            *bounds = Some(match bounds.take() {
-                Some(existing) => existing.joined(child_bounds),
-                None => child_bounds,
-            });
-
-            self.extend_bounds_with_subtree(child, bounds);
-        }
-    }
-
-    fn target_bounds(&self, target: &DesktopTarget) -> OverviewBounds {
-        let placement = self.placement(target);
-        let rect_px: RectPx = placement.rect.into();
-        let size = Rect::from(rect_px).size();
-        // `placement.transform` is anchor-space for this target. Convert to origin-space
-        // before transforming local rectangle corners.
-        let local_rect = size.to_rect();
-        let local_center = local_rect.center();
-        let origin_transform = placement.transform.to_origin_space(local_center);
-        Self::transform_rect(local_rect, origin_transform)
-    }
-
-    fn target_rect(&self, target: &DesktopTarget) -> Rect {
-        let placement = self.placement(target);
-        let rect_px: RectPx = placement.rect.into();
-        let size = Rect::from(rect_px).size();
-        let local_rect = size.to_rect();
-        let local_center = local_rect.center();
-        let origin_transform = placement.transform.to_origin_space(local_center);
-        let bounds = Self::transform_rect(local_rect, origin_transform);
-        bounds.rect
-    }
-
     pub(super) fn resolve_camera_for_target_and_or_ancestor_of(
         &self,
         target: &DesktopTarget,
@@ -254,6 +142,53 @@ impl DesktopSystem {
         Some(center.to_camera().with_size(rect.size()))
     }
 
+    pub(super) fn launcher_bounds(&self, launcher_id: LaunchProfileId) -> OverviewBounds {
+        let root = DesktopTarget::Launcher(launcher_id);
+        let mut bounds = Some(self.target_bounds(&root));
+        self.extend_bounds_with_subtree(&root, &mut bounds);
+        bounds.expect("Internal error: launcher bounds should always exist")
+    }
+
+    pub(super) fn matrix_row_rect(&self, launcher_id: LaunchProfileId) -> Option<Rect> {
+        let project_id = self.aggregates.hierarchy.project_of_launcher(launcher_id)?;
+        let row = self.aggregates.launchers.get(&launcher_id)?.placement.row;
+        let mut rect: Option<Rect> = None;
+
+        for target in self
+            .aggregates
+            .hierarchy
+            .get_nested(&DesktopTarget::ProjectMatrix(project_id))
+        {
+            let DesktopTarget::Launcher(candidate_launcher) = target else {
+                continue;
+            };
+
+            let Some(candidate) = self.aggregates.launchers.get(candidate_launcher) else {
+                continue;
+            };
+
+            if candidate.placement.row != row {
+                continue;
+            }
+
+            let launcher_rect = self.target_rect(&DesktopTarget::Launcher(*candidate_launcher));
+
+            rect = Some(match rect {
+                Some(existing) => existing.joined(launcher_rect),
+                None => launcher_rect,
+            });
+        }
+
+        rect.map(|matrix_row_rect| self.with_desktop_width(matrix_row_rect))
+    }
+
+    pub(super) fn project_rect(&self, project_id: crate::projects::ProjectId) -> Rect {
+        let root = DesktopTarget::Project(project_id);
+        let mut rect = Some(self.target_rect(&root));
+        self.extend_rect_with_subtree(&root, &mut rect);
+        self.with_desktop_width(rect.expect("Internal error: project bounds should always exist"))
+    }
+
     fn fit_size_for_points(
         rect: Rect,
         center: Vector3,
@@ -326,6 +261,62 @@ impl DesktopSystem {
         }
 
         true
+    }
+
+    fn with_desktop_width(&self, rect: Rect) -> Rect {
+        let desktop_rect = self.target_rect(&DesktopTarget::Desktop);
+        (desktop_rect.left, rect.top, desktop_rect.right, rect.bottom).into()
+    }
+
+    fn extend_rect_with_subtree(&self, root: &DesktopTarget, rect: &mut Option<Rect>) {
+        for child in self.aggregates.hierarchy.get_nested(root) {
+            let child_rect = self.target_rect(child);
+            *rect = Some(match *rect {
+                Some(existing) => existing.joined(child_rect),
+                None => child_rect,
+            });
+
+            self.extend_rect_with_subtree(child, rect);
+        }
+    }
+
+    fn target_rect(&self, target: &DesktopTarget) -> Rect {
+        let placement = self.placement(target);
+        let rect_px: RectPx = placement.rect.into();
+        let size = Rect::from(rect_px).size();
+        let local_rect = size.to_rect();
+        let local_center = local_rect.center();
+        let origin_transform = placement.transform.to_origin_space(local_center);
+        let bounds = Self::transform_rect(local_rect, origin_transform);
+        bounds.rect
+    }
+
+    fn extend_bounds_with_subtree(
+        &self,
+        root: &DesktopTarget,
+        bounds: &mut Option<OverviewBounds>,
+    ) {
+        for child in self.aggregates.hierarchy.get_nested(root) {
+            let child_bounds = self.target_bounds(child);
+            *bounds = Some(match bounds.take() {
+                Some(existing) => existing.joined(child_bounds),
+                None => child_bounds,
+            });
+
+            self.extend_bounds_with_subtree(child, bounds);
+        }
+    }
+
+    fn target_bounds(&self, target: &DesktopTarget) -> OverviewBounds {
+        let placement = self.placement(target);
+        let rect_px: RectPx = placement.rect.into();
+        let size = Rect::from(rect_px).size();
+        // `placement.transform` is anchor-space for this target. Convert to origin-space
+        // before transforming local rectangle corners.
+        let local_rect = size.to_rect();
+        let local_center = local_rect.center();
+        let origin_transform = placement.transform.to_origin_space(local_center);
+        Self::transform_rect(local_rect, origin_transform)
     }
 
     fn transform_rect(rect: Rect, transform: Transform) -> OverviewBounds {

--- a/desktop/src/desktop_system/zoom_navigation.rs
+++ b/desktop/src/desktop_system/zoom_navigation.rs
@@ -1,11 +1,10 @@
 use massive_geometry::{PixelCamera, Rect, RectPx, Size, SizePx, Vector3};
-use massive_layout::LayoutTopology;
 use massive_scene::{ToCamera, Transform};
 
 use super::{DesktopSystem, DesktopTarget, UserState};
 use crate::desktop_system::topology::DesktopTopology;
 use crate::desktop_system::{FocusDepth, LauncherMap};
-use crate::projects::{LaunchProfileId, ProjectId};
+use crate::projects::LaunchProfileId;
 
 #[derive(Debug, Clone)]
 pub(super) struct OverviewBounds {
@@ -43,54 +42,7 @@ pub fn zoom_out(
     Some(user_state)
 }
 
-// pub fn overview_target_for_navigation_candidate(
-//     topology: &DesktopTopology,
-//     current: &OverviewTarget,
-//     candidate: &DesktopTarget,
-// ) -> Option<OverviewTarget> {
-//     match current {
-//         OverviewTarget::Visor(current_launcher) => {
-//             let candidate_launcher = topology.launcher_of_target(candidate)?;
-//             (candidate_launcher == *current_launcher)
-//                 .then_some(OverviewTarget::Visor(*current_launcher))
-//         }
-//         OverviewTarget::MatrixRow(current_launcher) => {
-//             let current_project = topology.project_of_launcher(*current_launcher)?;
-//             let candidate_launcher = topology.launcher_of_target(candidate)?;
-//             let candidate_project = topology.project_of_launcher(candidate_launcher)?;
-
-//             (candidate_project == current_project)
-//                 .then_some(OverviewTarget::MatrixRow(candidate_launcher))
-//         }
-//         OverviewTarget::Project(current_project) => {
-//             let candidate_project = topology.project_of_target(candidate)?;
-//             (candidate_project == *current_project)
-//                 .then_some(OverviewTarget::Project(*current_project))
-//         }
-//         OverviewTarget::Desktop => Some(OverviewTarget::Desktop),
-//     }
-// }
-
-// impl DesktopSystem {
-//     pub(super) fn camera_for_overview_target(
-//         &self,
-//         target: &OverviewTarget,
-//     ) -> Option<PixelCamera> {
-//         match target {
-//             OverviewTarget::Visor(launcher_id) => {
-//                 self.camera_for_bounds(self.launcher_bounds(*launcher_id))
-//             }
-//             OverviewTarget::MatrixRow(launcher_id) => {
-//                 self.camera_for_rect(self.matrix_row_rect(*launcher_id)?)
-//             }
-//             OverviewTarget::Project(project_id) => {
-//                 self.camera_for_rect(self.project_rect(*project_id))
-//             }
-//             OverviewTarget::Desktop => self.camera_for_target(&DesktopTarget::Desktop),
-//         }
-//     }
-// }
-
+#[allow(dead_code)]
 fn focus_depth_from_target(target: DesktopTarget) -> FocusDepth {
     match target {
         DesktopTarget::View(_) => FocusDepth::Instance,
@@ -101,160 +53,6 @@ fn focus_depth_from_target(target: DesktopTarget) -> FocusDepth {
         | DesktopTarget::ProjectMatrix(_) => FocusDepth::Project,
         DesktopTarget::Desktop => FocusDepth::Desktop,
     }
-}
-
-// fn first_overview_target_for_launcher(
-//     topology: &DesktopTopology,
-//     launchers: &LauncherMap,
-//     launcher_id: LaunchProfileId,
-// ) -> OverviewTarget {
-//     if should_include_visor_level(topology, launcher_id) {
-//         return OverviewTarget::Visor(launcher_id);
-//     }
-
-//     if should_include_matrix_row_level(topology, launchers, launcher_id) {
-//         return OverviewTarget::MatrixRow(launcher_id);
-//     }
-
-//     topology
-//         .project_of_launcher(launcher_id)
-//         .map(OverviewTarget::Project)
-//         .unwrap_or(OverviewTarget::Desktop)
-// }
-
-// fn next_inward_user_state(
-//     topology: &DesktopTopology,
-//     launchers: &LauncherMap,
-//     focused: DesktopTarget,
-//     current: &OverviewTarget,
-// ) -> UserState {
-//     match current {
-//         OverviewTarget::Desktop => topology
-//             .project_of_target(&focused)
-//             .map(OverviewTarget::Project)
-//             .map(UserState::Overview)
-//             .unwrap_or(UserState::Instance),
-//         OverviewTarget::Project(project_id) => {
-//             let Some(launcher_id) =
-//                 zoom_context_launcher_for_project(topology, focused, *project_id)
-//             else {
-//                 return UserState::Instance;
-//             };
-
-//             deepest_overview_target_for_launcher(topology, launchers, launcher_id)
-//                 .map(UserState::Overview)
-//                 .unwrap_or(UserState::Instance)
-//         }
-//         OverviewTarget::MatrixRow(launcher_id) => {
-//             if should_include_visor_level(topology, *launcher_id) {
-//                 UserState::Overview(OverviewTarget::Visor(*launcher_id))
-//             } else {
-//                 UserState::Instance
-//             }
-//         }
-//         OverviewTarget::Visor(_) => UserState::Instance,
-//     }
-// }
-
-// fn deepest_overview_target_for_launcher(
-//     topology: &DesktopTopology,
-//     launchers: &LauncherMap,
-//     launcher_id: LaunchProfileId,
-// ) -> Option<OverviewTarget> {
-//     if should_include_matrix_row_level(topology, launchers, launcher_id) {
-//         return Some(OverviewTarget::MatrixRow(launcher_id));
-//     }
-
-//     if should_include_visor_level(topology, launcher_id) {
-//         return Some(OverviewTarget::Visor(launcher_id));
-//     }
-
-//     None
-// }
-
-// fn next_outward_overview_target(
-//     topology: &DesktopTopology,
-//     launchers: &LauncherMap,
-//     focused: DesktopTarget,
-//     current: &OverviewTarget,
-// ) -> OverviewTarget {
-//     match current {
-//         OverviewTarget::Visor(launcher_id) => {
-//             if should_include_matrix_row_level(topology, launchers, *launcher_id) {
-//                 OverviewTarget::MatrixRow(*launcher_id)
-//             } else {
-//                 zoom_transition_project(topology, focused, *launcher_id)
-//                     .map(OverviewTarget::Project)
-//                     .unwrap_or(OverviewTarget::Desktop)
-//             }
-//         }
-//         OverviewTarget::MatrixRow(launcher_id) => {
-//             zoom_transition_project(topology, focused, *launcher_id)
-//                 .map(OverviewTarget::Project)
-//                 .unwrap_or(OverviewTarget::Desktop)
-//         }
-//         OverviewTarget::Project(_) | OverviewTarget::Desktop => OverviewTarget::Desktop,
-//     }
-// }
-
-fn zoom_transition_project(
-    topology: &DesktopTopology,
-    focused: DesktopTarget,
-    launcher_id: LaunchProfileId,
-) -> Option<ProjectId> {
-    topology
-        .project_of_target(&focused)
-        .or_else(|| topology.project_of_launcher(launcher_id))
-}
-
-fn should_include_visor_level(topology: &DesktopTopology, launcher_id: LaunchProfileId) -> bool {
-    topology
-        .children_of(&DesktopTarget::Launcher(launcher_id))
-        .iter()
-        .filter(|target| matches!(target, DesktopTarget::Instance(_)))
-        .count()
-        > 1
-}
-
-fn should_include_matrix_row_level(
-    topology: &DesktopTopology,
-    launchers: &LauncherMap,
-    launcher_id: LaunchProfileId,
-) -> bool {
-    let Some(project_id) = topology.project_of_launcher(launcher_id) else {
-        return false;
-    };
-
-    let Some(row) = launchers.get(&launcher_id).map(|l| l.placement.row) else {
-        return false;
-    };
-
-    let launcher_count = topology
-        .children_of(&DesktopTarget::ProjectMatrix(project_id))
-        .iter()
-        .filter_map(|target| match target {
-            DesktopTarget::Launcher(candidate_launcher) => launchers.get(candidate_launcher),
-            _ => None,
-        })
-        .filter(|launcher| launcher.placement.row == row)
-        .count();
-
-    launcher_count > 1
-}
-
-fn zoom_context_launcher_for_project(
-    topology: &DesktopTopology,
-    focused: DesktopTarget,
-    project_id: ProjectId,
-) -> Option<crate::projects::LaunchProfileId> {
-    // Simplify: Can't we use project_of_target directly here?
-    if let Some(focused_launcher) = topology.launcher_of_target(&focused)
-        && topology.project_of_launcher(focused_launcher) == Some(project_id)
-    {
-        return Some(focused_launcher);
-    }
-
-    None
 }
 
 impl DesktopSystem {

--- a/desktop/src/event_router.rs
+++ b/desktop/src/event_router.rs
@@ -93,7 +93,7 @@ where
         Ok(())
     }
 
-    pub fn focused(&self) -> Option<&T> {
+    pub fn keyboard_focus(&self) -> Option<&T> {
         self.keyboard_focus.as_ref()
     }
 


### PR DESCRIPTION
I'd like to create a simpler overview zoom logic in which focus navigation stays enabled and the camera then follows the target that is currently focused at a specific semantic zoom level.
